### PR TITLE
Fixed missing oauth2 token in api definition request

### DIFF
--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -141,7 +141,12 @@
     }
 
     function setOAuthHeader(xhr) {
-      xhr.setRequestHeader('Authorization', 'Bearer ' + OAuthProvider.getAccessToken());
+      var bearerHeader = 'Bearer ' + OAuthProvider.getAccessToken();
+      if (window.swaggerUi && window.swaggerUi.api) {
+        window.swaggerUi.api.clientAuthorizations.add('myoauth2',
+            new SwaggerClient.ApiKeyAuthorization('Authorization', bearerHeader, 'header'));
+      }
+      xhr.setRequestHeader('Authorization', bearerHeader);
     }
 
     function initWithFirstOf(apis) {

--- a/src/main/javascript/view/HeaderView.js
+++ b/src/main/javascript/view/HeaderView.js
@@ -27,7 +27,12 @@ SwaggerUi.Views.HeaderView = Backbone.View.extend({
         self = this;
 
     function setOAuthHeader(xhr) {
-      xhr.setRequestHeader('Authorization', 'Bearer ' + window.OAuthProvider.getAccessToken());
+      var bearerHeader = 'Bearer ' + window.OAuthProvider.getAccessToken();
+      if (window.swaggerUi && window.swaggerUi.api) {
+        window.swaggerUi.api.clientAuthorizations.add('myoauth2',
+            new SwaggerClient.ApiKeyAuthorization('Authorization', bearerHeader, 'header'));
+      }
+      xhr.setRequestHeader('Authorization', bearerHeader);
     }
 
     $.ajax({


### PR DESCRIPTION
Loading api definition which needs an authentication token fails due the header is not set currently. This is solved by this commit.