### PR TITLE
Simplify definition loading

### DIFF
--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -10,7 +10,6 @@
     SUIENV_OAUTH_CLIENT_ID='stups_swagger';
     SUIENV_OAUTH_AUTH_URL='http://localhost:5002/auth';
     SUIENV_OAUTH_REDIRECT_URL='http://localhost:3000';
-    SUIENV_KIO_BASE_URL='http://localhost:5000';
     SUIENV_TWINTIP_BASE_URL='http://localhost:5001';
     SUIENV_OAUTH_TOKENINFO_URL='http://localhost:5006/tokeninfo';
   </script> -->

--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -117,6 +117,9 @@
           docExpansion: "none",
           sorter : "alpha"
         });
+        window.swaggerUi.api = new SwaggerClient({ url: this.url });
+        window.swaggerUi.api.clientAuthorizations.add('myoauth2',
+            new SwaggerClient.ApiKeyAuthorization('Authorization', 'Bearer ' + OAuthProvider.getAccessToken(), 'header'));
         window.swaggerUi.load();
       }
 
@@ -141,44 +144,15 @@
     }
 
     function setOAuthHeader(xhr) {
-      var bearerHeader = 'Bearer ' + OAuthProvider.getAccessToken();
-      if (window.swaggerUi && window.swaggerUi.api) {
-        window.swaggerUi.api.clientAuthorizations.add('myoauth2',
-            new SwaggerClient.ApiKeyAuthorization('Authorization', bearerHeader, 'header'));
-      }
-      xhr.setRequestHeader('Authorization', bearerHeader);
+      xhr.setRequestHeader('Authorization', 'Bearer ' + OAuthProvider.getAccessToken());
     }
 
     function initWithFirstOf(apis) {
       if (!apis.length) {
         return initSwagger(window.SUIENV_TWINTIP_BASE_URL + '/swagger.json');
+      } else {
+        return initSwagger(window.SUIENV_TWINTIP_BASE_URL + '/apps/' + apis[0].application_id + '/definition');
       }
-      var first = apis[0];
-      $.ajax({
-        url: window.SUIENV_TWINTIP_BASE_URL + '/apps/' + first.application_id,
-        type: 'GET',
-        dataType: 'json',
-        beforeSend: setOAuthHeader,
-        error: console.error.bind(console),
-        success: function(api) {
-          var swaggerUrl = api.url,
-              isRelativeUrl = swaggerUrl[0] === '/';
-          if (isRelativeUrl) {
-            $.ajax({
-              url: window.SUIENV_KIO_BASE_URL + '/apps/' + first.application_id,
-              type: 'GET',
-              dataType: 'json',
-              beforeSend: setOAuthHeader,
-              error: console.error.bind(console),
-              success: function(app) {
-                initSwagger(app.service_url + swaggerUrl);
-              }
-            });
-          } else {
-            initSwagger(swaggerUrl);
-          }
-        }
-      });
     }
 
     $.ajax({

--- a/src/main/javascript/view/HeaderView.js
+++ b/src/main/javascript/view/HeaderView.js
@@ -23,47 +23,9 @@ SwaggerUi.Views.HeaderView = Backbone.View.extend({
   },
 
   loadDefinition: function(e) {
-    var app_id = $(e.target).children(':selected').val(),
-        self = this;
-
-    function setOAuthHeader(xhr) {
-      var bearerHeader = 'Bearer ' + window.OAuthProvider.getAccessToken();
-      if (window.swaggerUi && window.swaggerUi.api) {
-        window.swaggerUi.api.clientAuthorizations.add('myoauth2',
-            new SwaggerClient.ApiKeyAuthorization('Authorization', bearerHeader, 'header'));
-      }
-      xhr.setRequestHeader('Authorization', bearerHeader);
-    }
-
-    $.ajax({
-        url: window.SUIENV_TWINTIP_BASE_URL + '/apps/' + app_id,
-        type: 'GET',
-        dataType: 'json',
-        beforeSend: setOAuthHeader,
-        error: console.error.bind(console),
-        success: function(api) {
-          var swaggerUrl = api.url,
-              isRelativeUrl = swaggerUrl[0] === '/';
-          if (isRelativeUrl) {
-            // go to kio for serviceurl
-            $.ajax({
-              url: window.SUIENV_KIO_BASE_URL + '/apps/' + app_id,
-              type: 'GET',
-              dataType: 'json',
-              beforeSend: setOAuthHeader,
-              error: console.error.bind(console),
-              success: function(app) {
-                self.trigger('update-swagger-ui', {
-                  url: app.service_url + swaggerUrl
-                });
-              }
-            });
-          } else {
-            self.trigger('update-swagger-ui', {
-              url: swaggerUrl
-            });
-          }
-      }
+    var app_id = $(e.target).children(':selected').val();
+    this.trigger('update-swagger-ui', {
+      url: window.SUIENV_TWINTIP_BASE_URL + '/apps/' + app_id + '/definition'
     });
   },
 

--- a/test-docker.sh
+++ b/test-docker.sh
@@ -1,7 +1,6 @@
 docker run \
     -it \
     -p 8080:8080 \
-    -e SUIENV_KIO_BASE_URL=http://localhost:5000 \
     -e SUIENV_TWINTIP_BASE_URL=http://localhost:5001 \
     -e SUIENV_OAUTH_REALM=realm \
     -e SUIENV_OAUTH_CLIENT_ID=swagger \


### PR DESCRIPTION
This change removes dependency to kio. The UI loads the api definitions directly from twintip-storage where they are already persisted. By this, the whole twintip setup will become more robust due less services are called for api definition loading.

CAUTION: This pull request has a deploy dependency! Following PR https://github.com/zalando-stups/twintip-storage/pull/3 has to be merged and deployed, otherwise the required definition endpoint is not present.