### PR TITLE
Add application id to selectbox

### DIFF
--- a/src/main/html/index.html
+++ b/src/main/html/index.html
@@ -135,7 +135,7 @@
       apis.forEach(function(api) {
         var $option = $('<option />');
         $option.attr('value', api.application_id);
-        $option.text(api.name);
+        $option.text(api.name + ' (' + api.application_id + ')');
         $select.append($option);
       });
     }


### PR DESCRIPTION
Minor ui improvement: adds appid to selectbox - for the case when you have same api definitions from many hosts.